### PR TITLE
feat: add mission CRUD operations with moderation system

### DIFF
--- a/backend/src/main/java/com/example/alabuga/controller/MissionController.java
+++ b/backend/src/main/java/com/example/alabuga/controller/MissionController.java
@@ -3,15 +3,19 @@ package com.example.alabuga.controller;
 import java.util.List;
 
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
+import com.example.alabuga.dto.MissionCreateDTO;
 import com.example.alabuga.dto.MissionDTO;
+import com.example.alabuga.dto.MissionUpdateDTO;
 import com.example.alabuga.dto.UserMissionDTO;
 import com.example.alabuga.service.MissionService;
 
@@ -94,6 +98,40 @@ public class MissionController {
             @Parameter(description = "ID пользователя") @RequestParam Long userId,
             @Parameter(description = "ID миссии") @RequestParam Long missionId) {
         UserMissionDTO userMission = missionService.completeMission(userId, missionId);
+        return ResponseEntity.ok(userMission);
+    }
+
+    @PostMapping
+    @Operation(summary = "Создать миссию")
+    public ResponseEntity<MissionDTO> createMission(@RequestBody MissionCreateDTO missionCreateDTO) {
+        MissionDTO mission = missionService.createMission(missionCreateDTO);
+        return ResponseEntity.ok(mission);
+    }
+
+    @PutMapping("/{id}")
+    @Operation(summary = "Обновить миссию")
+    public ResponseEntity<MissionDTO> updateMission(
+            @Parameter(description = "ID миссии") @PathVariable Long id,
+            @RequestBody MissionUpdateDTO missionUpdateDTO) {
+        MissionDTO mission = missionService.updateMission(id, missionUpdateDTO);
+        return ResponseEntity.ok(mission);
+    }
+
+    @DeleteMapping("/{id}")
+    @Operation(summary = "Удалить миссию")
+    public ResponseEntity<Void> deleteMission(
+            @Parameter(description = "ID миссии") @PathVariable Long id) {
+        missionService.deleteMission(id);
+        return ResponseEntity.ok().build();
+    }
+
+    @PostMapping("/moderate")
+    @Operation(summary = "Модерировать миссию")
+    public ResponseEntity<UserMissionDTO> moderateMission(
+            @Parameter(description = "ID пользователя") @RequestParam Long userId,
+            @Parameter(description = "ID миссии") @RequestParam Long missionId,
+            @Parameter(description = "Одобрено ли") @RequestParam Boolean approved) {
+        UserMissionDTO userMission = missionService.moderateMission(userId, missionId, approved);
         return ResponseEntity.ok(userMission);
     }
 }

--- a/backend/src/main/java/com/example/alabuga/dto/MissionCreateDTO.java
+++ b/backend/src/main/java/com/example/alabuga/dto/MissionCreateDTO.java
@@ -1,0 +1,65 @@
+package com.example.alabuga.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Positive;
+import jakarta.validation.constraints.Size;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@Schema(description = "DTO для создания миссии")
+public class MissionCreateDTO {
+
+    @NotBlank(message = "Название миссии не может быть пустым")
+    @Size(max = 200, message = "Название миссии не может превышать 200 символов")
+    @Schema(description = "Название миссии", example = "Первые шаги в космосе", required = true)
+    private String name;
+
+    @Size(max = 1000, message = "Описание миссии не может превышать 1000 символов")
+    @Schema(description = "Описание миссии", example = "Изучите основы космических путешествий")
+    private String description;
+
+    @NotNull(message = "ID ветки миссии обязателен")
+    @Schema(description = "ID ветки миссии", example = "1", required = true)
+    private Long branchId;
+
+    @NotNull(message = "Тип миссии обязателен")
+    @Schema(description = "Тип миссии", example = "TUTORIAL", required = true)
+    private String type;
+
+    @NotNull(message = "Сложность миссии обязательна")
+    @Schema(description = "Сложность миссии", example = "EASY", required = true)
+    private String difficulty;
+
+    @NotNull(message = "Награда опыта обязательна")
+    @Positive(message = "Награда опыта должна быть положительной")
+    @Schema(description = "Награда опыта", example = "50", required = true)
+    private Integer experienceReward;
+
+    @NotNull(message = "Награда маны обязательна")
+    @Positive(message = "Награда маны должна быть положительной")
+    @Schema(description = "Награда маны", example = "25", required = true)
+    private Integer manaReward;
+
+    @Size(max = 500, message = "Требуемые компетенции не могут превышать 500 символов")
+    @Schema(description = "Требуемые компетенции (JSON)", example = "[\"navigation\", \"engineering\"]")
+    private String requiredCompetencies;
+
+    @Builder.Default
+    @Schema(description = "Активна ли миссия", example = "true", defaultValue = "true")
+    private Boolean isActive = true;
+
+    @Builder.Default
+    @Schema(description = "Требует ли миссия модерации", example = "false", defaultValue = "false")
+    private Boolean requiresModeration = false;
+
+    @Schema(description = "ID артефакта в качестве награды", example = "1")
+    private Long artifactRewardId;
+}

--- a/backend/src/main/java/com/example/alabuga/dto/MissionUpdateDTO.java
+++ b/backend/src/main/java/com/example/alabuga/dto/MissionUpdateDTO.java
@@ -1,6 +1,8 @@
 package com.example.alabuga.dto;
 
 import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.Positive;
+import jakarta.validation.constraints.Size;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
@@ -10,37 +12,36 @@ import lombok.NoArgsConstructor;
 @Builder
 @NoArgsConstructor
 @AllArgsConstructor
-@Schema(description = "DTO для миссии")
-public class MissionDTO {
+@Schema(description = "DTO для обновления миссии")
+public class MissionUpdateDTO {
 
-    @Schema(description = "Уникальный идентификатор миссии", example = "1")
-    private Long id;
-
+    @Size(max = 200, message = "Название миссии не может превышать 200 символов")
     @Schema(description = "Название миссии", example = "Первые шаги в космосе")
     private String name;
 
+    @Size(max = 1000, message = "Описание миссии не может превышать 1000 символов")
     @Schema(description = "Описание миссии", example = "Изучите основы космических путешествий")
     private String description;
 
     @Schema(description = "ID ветки миссии", example = "1")
     private Long branchId;
 
-    @Schema(description = "Название ветки", example = "Док Лунной Базы")
-    private String branchName;
-
-    @Schema(description = "Тип миссии")
+    @Schema(description = "Тип миссии", example = "TUTORIAL")
     private String type;
 
-    @Schema(description = "Сложность миссии")
+    @Schema(description = "Сложность миссии", example = "EASY")
     private String difficulty;
 
+    @Positive(message = "Награда опыта должна быть положительной")
     @Schema(description = "Награда опыта", example = "50")
     private Integer experienceReward;
 
+    @Positive(message = "Награда маны должна быть положительной")
     @Schema(description = "Награда маны", example = "25")
     private Integer manaReward;
 
-    @Schema(description = "Требуемые компетенции", example = "[\"navigation\", \"engineering\"]")
+    @Size(max = 500, message = "Требуемые компетенции не могут превышать 500 символов")
+    @Schema(description = "Требуемые компетенции (JSON)", example = "[\"navigation\", \"engineering\"]")
     private String requiredCompetencies;
 
     @Schema(description = "Активна ли миссия", example = "true")

--- a/backend/src/main/java/com/example/alabuga/entity/Mission.java
+++ b/backend/src/main/java/com/example/alabuga/entity/Mission.java
@@ -66,4 +66,13 @@ public class Mission {
     @Builder.Default
     @Schema(description = "Активна ли миссия", example = "true", defaultValue = "true")
     private Boolean isActive = true;
+
+    @Column(name = "requires_moderation", nullable = false)
+    @Builder.Default
+    @Schema(description = "Требует ли миссия модерации", example = "false", defaultValue = "false")
+    private Boolean requiresModeration = false;
+
+    @Column(name = "artifact_reward_id")
+    @Schema(description = "ID артефакта в качестве награды", example = "1")
+    private Long artifactRewardId;
 }

--- a/backend/src/main/java/com/example/alabuga/mapper/MissionMapper.java
+++ b/backend/src/main/java/com/example/alabuga/mapper/MissionMapper.java
@@ -5,10 +5,14 @@ import java.util.stream.Collectors;
 
 import org.springframework.stereotype.Component;
 
+import com.example.alabuga.dto.MissionCreateDTO;
 import com.example.alabuga.dto.MissionDTO;
+import com.example.alabuga.dto.MissionUpdateDTO;
 import com.example.alabuga.dto.UserMissionDTO;
 import com.example.alabuga.entity.Mission;
 import com.example.alabuga.entity.MissionBranch;
+import com.example.alabuga.entity.MissionDifficulty;
+import com.example.alabuga.entity.MissionType;
 import com.example.alabuga.entity.UserMission;
 
 @Component
@@ -33,6 +37,8 @@ public class MissionMapper {
                 .manaReward(mission.getManaReward())
                 .requiredCompetencies(mission.getRequiredCompetencies())
                 .isActive(mission.getIsActive())
+                .requiresModeration(mission.getRequiresModeration())
+                .artifactRewardId(mission.getArtifactRewardId())
                 .build();
     }
     
@@ -77,6 +83,82 @@ public class MissionMapper {
                 .collect(Collectors.toList());
     }
     
+    public Mission toEntity(MissionCreateDTO dto) {
+        if (dto == null) {
+            return null;
+        }
+
+        return Mission.builder()
+                .name(dto.getName())
+                .description(dto.getDescription())
+                .branchId(dto.getBranchId())
+                .type(parseMissionType(dto.getType()))
+                .difficulty(parseMissionDifficulty(dto.getDifficulty()))
+                .experienceReward(dto.getExperienceReward())
+                .manaReward(dto.getManaReward())
+                .requiredCompetencies(dto.getRequiredCompetencies())
+                .isActive(dto.getIsActive() != null ? dto.getIsActive() : true)
+                .requiresModeration(dto.getRequiresModeration() != null ? dto.getRequiresModeration() : false)
+                .artifactRewardId(dto.getArtifactRewardId())
+                .build();
+    }
+
+    public void updateEntity(Mission mission, MissionUpdateDTO dto) {
+        if (mission == null || dto == null) {
+            return;
+        }
+
+        if (dto.getName() != null) {
+            mission.setName(dto.getName());
+        }
+        if (dto.getDescription() != null) {
+            mission.setDescription(dto.getDescription());
+        }
+        if (dto.getBranchId() != null) {
+            mission.setBranchId(dto.getBranchId());
+        }
+        if (dto.getType() != null) {
+            mission.setType(parseMissionType(dto.getType()));
+        }
+        if (dto.getDifficulty() != null) {
+            mission.setDifficulty(parseMissionDifficulty(dto.getDifficulty()));
+        }
+        if (dto.getExperienceReward() != null) {
+            mission.setExperienceReward(dto.getExperienceReward());
+        }
+        if (dto.getManaReward() != null) {
+            mission.setManaReward(dto.getManaReward());
+        }
+        if (dto.getRequiredCompetencies() != null) {
+            mission.setRequiredCompetencies(dto.getRequiredCompetencies());
+        }
+        if (dto.getIsActive() != null) {
+            mission.setIsActive(dto.getIsActive());
+        }
+        if (dto.getRequiresModeration() != null) {
+            mission.setRequiresModeration(dto.getRequiresModeration());
+        }
+        if (dto.getArtifactRewardId() != null) {
+            mission.setArtifactRewardId(dto.getArtifactRewardId());
+        }
+    }
+
+    private MissionType parseMissionType(String type) {
+        try {
+            return MissionType.valueOf(type);
+        } catch (IllegalArgumentException e) {
+            return MissionType.QUEST; // Default value
+        }
+    }
+
+    private MissionDifficulty parseMissionDifficulty(String difficulty) {
+        try {
+            return MissionDifficulty.valueOf(difficulty);
+        } catch (IllegalArgumentException e) {
+            return MissionDifficulty.EASY; // Default value
+        }
+    }
+
     private String getBranchName(Long branchId) {
         try {
             MissionBranch branch = MissionBranch.fromId(branchId);

--- a/backend/src/main/java/com/example/alabuga/repository/UserMissionRepository.java
+++ b/backend/src/main/java/com/example/alabuga/repository/UserMissionRepository.java
@@ -8,6 +8,7 @@ import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
+import com.example.alabuga.entity.MissionStatus;
 import com.example.alabuga.entity.UserMission;
 
 @Repository
@@ -24,4 +25,6 @@ public interface UserMissionRepository extends JpaRepository<UserMission, Long> 
     
     @Query("SELECT um FROM UserMission um WHERE um.user.id = :userId AND um.mission.branchId = :branchId")
     List<UserMission> findByUserIdAndBranchId(@Param("userId") Long userId, @Param("branchId") Long branchId);
+    
+    List<UserMission> findByMissionIdAndStatusIn(Long missionId, List<MissionStatus> statuses);
 }


### PR DESCRIPTION
- Add requiresModeration and artifactRewardId fields to Mission entity
- Implement full CRUD operations for missions (create, read, update, delete)
- Add mission moderation system - missions requiring moderation cannot be completed by users
- Add artifact rewards for missions (optional artifactRewardId field)
- Create MissionCreateDTO and MissionUpdateDTO with validation
- Add moderation endpoint for approving/rejecting missions
- Update mission completion logic to respect moderation requirements
- Add comprehensive Swagger documentation for all new endpoints

API endpoints:
- POST /api/missions - create mission
- PUT /api/missions/{id} - update mission
- DELETE /api/missions/{id} - delete mission
- POST /api/missions/moderate - moderate mission